### PR TITLE
Make the counter config driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # practice-counter
 A small app for tracking your success/failure rate while practicing something
+
+To customize button names/count/hotkeys, edit the file `config.ini`. To add an entirely new button, add new name to the `buttons` list under `[SETTINGS]` and then add a new section with the same name under `[BUTTON2]`

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,14 @@
+[SETTINGS]
+counter_name = Practice Counter
+buttons = BUTTON1, BUTTON2
+
+[BUTTON1]
+label = Success!
+hotkey = 1
+success = True
+
+[BUTTON2]
+label = Failure!
+hotkey = 2
+success = False
+

--- a/ini_defaults.py
+++ b/ini_defaults.py
@@ -1,0 +1,34 @@
+import configparser
+import os
+
+from pathlib import Path
+
+DIR_PATH = Path(os.path.dirname(os.path.realpath(__file__)))
+CONFIG_PATH = DIR_PATH / 'config.ini'
+
+def create_default_counter_config():
+    config = configparser.ConfigParser()
+    config['SETTINGS'] = {
+        'counter_name': 'Practice Counter',
+        'buttons': 'BUTTON1, BUTTON2',}
+    config['BUTTON1'] = {
+        'label': 'Success!',
+        'hotkey': 1,
+        'success': True,}
+    config['BUTTON2'] = {
+        'label': 'Failure!',
+        'hotkey': 2,
+        'success': False,}
+
+    with open(CONFIG_PATH, 'w') as configfile:
+        config.write(configfile)
+
+    return config
+
+# If there is a config file, load it. If a config file doesn't exist, write one
+def get_config_file_or_default():
+    if CONFIG_PATH.exists():
+        config = configparser.ConfigParser()
+        config.read(CONFIG_PATH)
+        return config
+    return create_default_counter_config()


### PR DESCRIPTION
Ideally when I add more customizable features I'll add them to `config.ini`, and it will grow bloated and unmanageable, yay!